### PR TITLE
Add camera path pan system to checkpoints

### DIFF
--- a/Truth and Shadows/Assets/Character Model.meta
+++ b/Truth and Shadows/Assets/Character Model.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2a91b711074bf7a4abffdd1f9fb104ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Truth and Shadows/Assets/Prefabs/Interactables/LightInteractables/Checkpoint.prefab
+++ b/Truth and Shadows/Assets/Prefabs/Interactables/LightInteractables/Checkpoint.prefab
@@ -1,5 +1,100 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2338774532318243740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3926620783953414897}
+  - component: {fileID: 341905489856870907}
+  - component: {fileID: 203719482254729571}
+  - component: {fileID: 6690372684802159491}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3926620783953414897
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2338774532318243740}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7557228040615293882}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &341905489856870907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2338774532318243740}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &203719482254729571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2338774532318243740}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &6690372684802159491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2338774532318243740}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 1
+  m_FollowOffset: {x: 0, y: 0, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
 --- !u!1 &2659512550723867644
 GameObject:
   m_ObjectHideFlags: 0
@@ -4831,7 +4926,7 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
---- !u!1 &3635961379081293272
+--- !u!1 &2676953555608812791
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4839,50 +4934,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4031297115881065051}
-  - component: {fileID: 6841790975731530351}
-  - component: {fileID: 4070192161845758066}
-  - component: {fileID: 2286432053159213132}
-  - component: {fileID: 6024622355916213053}
+  - component: {fileID: 7624674911201402425}
+  - component: {fileID: 1907513326739455798}
+  - component: {fileID: 3806141143238676136}
   m_Layer: 0
-  m_Name: Checkpoint
+  m_Name: Runes
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4031297115881065051
+--- !u!4 &7624674911201402425
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3635961379081293272}
+  m_GameObject: {fileID: 2676953555608812791}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: -184.6, y: 2.135, z: -8.06}
-  m_LocalScale: {x: 1, y: 1, z: 0.01}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3300216232431930501}
-  - {fileID: 6691883887541615233}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!33 &6841790975731530351
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3635961379081293272}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &4070192161845758066
+  m_Children: []
+  m_Father: {fileID: 4031297115881065051}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1907513326739455798
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3635961379081293272}
+  m_GameObject: {fileID: 2676953555608812791}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -4918,28 +5001,54 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!64 &2286432053159213132
-MeshCollider:
+--- !u!33 &3806141143238676136
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2676953555608812791}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &3635961379081293272
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4031297115881065051}
+  - component: {fileID: 6024622355916213053}
+  - component: {fileID: 8099359301811655236}
+  - component: {fileID: 5705959367394064739}
+  m_Layer: 0
+  m_Name: Checkpoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4031297115881065051
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3635961379081293272}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -184.6, y: 2.135, z: -8.06}
+  m_LocalScale: {x: 1, y: 1, z: 0.01}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7624674911201402425}
+  - {fileID: 3300216232431930501}
+  - {fileID: 6691883887541615233}
+  - {fileID: 7557228040615293882}
+  - {fileID: 8927333038386948584}
+  - {fileID: 6992769712638424685}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!114 &6024622355916213053
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4963,7 +5072,125 @@ MonoBehaviour:
   activationSound: {fileID: 0}
   audioSource: {fileID: 0}
   isSpawnCheckpoint: 0
+  oneTimeCameraPath: 1
+  cameraPanPriority: 15
   devOverrideSpawn: 0
+  runesTransform: {fileID: 7624674911201402425}
+--- !u!114 &8099359301811655236
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3635961379081293272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bba8596736980d94d9675885e0707c9c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vcam: {fileID: 1955331528345979448}
+  dollyCart: {fileID: 6014924431735526305}
+  moveSpeed: 4
+  speedTransitionTime: 0.5
+  speedCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  focusHoldTime: 2
+  rollThreshold: 0.1
+  tourPriority: 100
+  playOnce: 1
+--- !u!64 &5705959367394064739
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3635961379081293272}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &4612191063595736148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6992769712638424685}
+  - component: {fileID: 6014924431735526305}
+  m_Layer: 0
+  m_Name: Dolly Cart
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6992769712638424685
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4612191063595736148}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.82377625, y: -5.2184377, z: -112.85691}
+  m_LocalScale: {x: 1, y: 99.99998, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4031297115881065051}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6014924431735526305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4612191063595736148}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99a9c787e5d1bbf48a389834c4a9641c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Path: {fileID: 4144641169024661219}
+  m_UpdateMethod: 0
+  m_PositionUnits: 1
+  m_Speed: 0
+  m_Position: 0
 --- !u!1 &5212751310238113671
 GameObject:
   m_ObjectHideFlags: 0
@@ -9795,3 +10022,139 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
+--- !u!1 &7220882262203527404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8927333038386948584}
+  - component: {fileID: 4144641169024661219}
+  m_Layer: 0
+  m_Name: Dolly Track
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8927333038386948584
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7220882262203527404}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.82377625, y: -0.21843731, z: -112.8569}
+  m_LocalScale: {x: 1, y: 99.99998, z: 0.99999976}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4031297115881065051}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4144641169024661219
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7220882262203527404}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a200b19ca1a9685429ed7e043c28e904, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Resolution: 20
+  m_Appearance:
+    pathColor: {r: 0, g: 1, b: 0, a: 1}
+    inactivePathColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    width: 0.2
+  m_Looped: 0
+  m_Waypoints:
+  - position: {x: 0, y: 0, z: -5}
+    roll: 0
+  - position: {x: 0, y: 0, z: 5}
+    roll: 1
+  - position: {x: 0, y: 0, z: 15}
+    roll: 0
+--- !u!1 &8340927106205815071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7557228040615293882}
+  - component: {fileID: 1955331528345979448}
+  m_Layer: 0
+  m_Name: Virtual Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7557228040615293882
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8340927106205815071}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -30.277504, y: -8.365002, z: -274.00018}
+  m_LocalScale: {x: 0.5, y: 99.99998, z: 0.49999988}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3926620783953414897}
+  m_Father: {fileID: 4031297115881065051}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1955331528345979448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8340927106205815071}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 6992769712638424685}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 5000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+    Iso: 200
+    ShutterSpeed: 0.005
+    Aperture: 16
+    BladeCount: 5
+    Curvature: {x: 2, y: 11}
+    BarrelClipping: 0.25
+    Anamorphism: 0
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 3926620783953414897}

--- a/Truth and Shadows/Assets/Scripts/Camera/CameraPathPanController.cs
+++ b/Truth and Shadows/Assets/Scripts/Camera/CameraPathPanController.cs
@@ -1,0 +1,268 @@
+/*  Truth and Shadows – Dolly Nav Tour
+    ──────────────────────────────────
+    Put this on a GameObject in your checkpoint prefab.
+    Requirements:
+      • a CinemachineVirtualCamera with a CinemachineDollyCart component
+      • the DollyCart’s Track field to a Cinemachine Dolly Track in the scene
+      • “Position Units” on the DollyCart set to Distance   */
+
+using System.Collections;
+using Cinemachine;
+using UnityEngine;
+
+namespace TruthAndShadows.Interaction
+{
+    public class CameraPathPanController : MonoBehaviour
+    {
+        private const int HIGH_PRIORITY = 10000;
+        private const int DISABLED_PRIORITY = 0;
+
+        [Header("Camera Settings")]
+        [SerializeField]
+        private CinemachineVirtualCamera vcam;
+
+        [SerializeField]
+        private CinemachineDollyCart dollyCart;
+
+        [Header("Movement")]
+        [SerializeField]
+        private float moveSpeed = 4f;
+
+        [SerializeField]
+        private float speedTransitionTime = 0.5f; // Time to smoothly change speed
+
+        [SerializeField]
+        private AnimationCurve speedCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
+
+        [Header("Focus Points")]
+        [SerializeField]
+        private float focusHoldTime = 2f;
+
+        [SerializeField]
+        private float rollThreshold = 0.99f; // Minimum roll angle to trigger a pause
+
+        [Header("Camera Priority")]
+        [SerializeField]
+        private int tourPriority = 15;
+
+        [Header("Playback Settings")]
+        [SerializeField]
+        private bool playOnce = true;
+
+        private bool tourRunning;
+        private bool hasPlayed;
+        private float initialSpeed;
+
+        private float targetSpeed;
+        private float currentSpeed;
+        private Coroutine speedTransitionCoroutine;
+        private float lastPausePosition = -1f; // Track the last position we paused at
+        private float minPauseDistance = 1f; // Minimum distance between pause points
+
+        private void Start()
+        {
+            if (vcam == null)
+            {
+                vcam = GetComponent<CinemachineVirtualCamera>();
+            }
+
+            if (dollyCart == null)
+            {
+                dollyCart = GetComponent<CinemachineDollyCart>();
+            }
+
+            if (vcam != null && dollyCart != null)
+            {
+                // Start with camera disabled and cart stopped
+                vcam.Priority = DISABLED_PRIORITY;
+                initialSpeed = dollyCart.m_Speed;
+                currentSpeed = 0;
+                targetSpeed = 0;
+                dollyCart.m_Speed = 0;
+                Debug.Log($"[CameraPathPanController] Initialized with camera: {vcam.name}");
+            }
+            else
+            {
+                Debug.LogError("[CameraPathPanController] Missing required components!");
+            }
+        }
+
+        private void Update()
+        {
+            // Smoothly update the cart's speed
+            if (dollyCart != null && Mathf.Abs(dollyCart.m_Speed - targetSpeed) > 0.01f)
+            {
+                currentSpeed = Mathf.Lerp(
+                    currentSpeed,
+                    targetSpeed,
+                    Time.deltaTime / speedTransitionTime
+                );
+                dollyCart.m_Speed = currentSpeed;
+            }
+        }
+
+        public void PlayTourIfAble()
+        {
+            if (playOnce && hasPlayed)
+            {
+                Debug.Log("[CameraPathPanController] Tour already played (one-time only)");
+                return;
+            }
+
+            if (tourRunning || vcam == null || dollyCart == null)
+            {
+                Debug.LogWarning("[CameraPathPanController] Cannot play tour - check setup");
+                return;
+            }
+
+            // Set high priority to override other cameras
+            vcam.Priority = HIGH_PRIORITY;
+            Debug.Log(
+                $"[CameraPathPanController] Camera {vcam.name} set to priority {HIGH_PRIORITY}"
+            );
+
+            StartCoroutine(TourRoutine());
+            hasPlayed = true;
+        }
+
+        private IEnumerator TourRoutine()
+        {
+            tourRunning = true;
+
+            // Start movement
+            SetTargetSpeed(moveSpeed);
+
+            while (dollyCart.m_Position < dollyCart.m_Path.PathLength)
+            {
+                // Check if we're at a focus point
+                if (ShouldPauseAtCurrentPosition())
+                {
+                    yield return HandleFocusPoint();
+                }
+
+                yield return null;
+            }
+
+            // Ensure we've reached the final position
+            dollyCart.m_Position = dollyCart.m_Path.PathLength;
+            yield return new WaitForSeconds(0.5f); // Short delay at end
+
+            // Reset and disable
+            SetTargetSpeed(0);
+            vcam.Priority = DISABLED_PRIORITY;
+            tourRunning = false;
+            Debug.Log(
+                $"[CameraPathPanController] Tour completed, camera disabled (Priority: {DISABLED_PRIORITY})"
+            );
+        }
+
+        private void SetTargetSpeed(float speed)
+        {
+            targetSpeed = speed;
+            currentSpeed = dollyCart.m_Speed; // Start from current speed
+        }
+
+        private bool ShouldPauseAtCurrentPosition()
+        {
+            if (dollyCart?.m_Path == null)
+                return false;
+
+            float pathPosition = dollyCart.m_Position;
+
+            // Don't pause if we're too close to the last pause point
+            if (
+                lastPausePosition >= 0
+                && Mathf.Abs(pathPosition - lastPausePosition) < minPauseDistance
+            )
+            {
+                return false;
+            }
+
+            // Check if we're using a CinemachineSmoothPath
+            var smoothPath = dollyCart.m_Path as CinemachineSmoothPath;
+            if (smoothPath == null)
+            {
+                Debug.LogWarning("[CameraPathPanController] Path must be a CinemachineSmoothPath");
+                return false;
+            }
+
+            // Find the nearest waypoint
+            int waypointCount = smoothPath.m_Waypoints.Length;
+            float nearestWaypointDist = float.MaxValue;
+            int nearestWaypointIndex = -1;
+
+            // Convert current position to a normalized path position (0 to 1)
+            float normalizedPosition = pathPosition / smoothPath.PathLength;
+
+            for (int i = 0; i < waypointCount; i++)
+            {
+                // Get the normalized position of this waypoint
+                float wpPosition = (float)i / (waypointCount - 1);
+                float dist = Mathf.Abs(normalizedPosition - wpPosition);
+
+                if (dist < nearestWaypointDist)
+                {
+                    nearestWaypointDist = dist;
+                    nearestWaypointIndex = i;
+                }
+            }
+
+            // Only check roll if we're very close to a waypoint (in normalized space)
+            if (nearestWaypointDist > 0.01f) // Adjusted threshold for normalized space
+            {
+                return false;
+            }
+
+            // Get the roll directly from the waypoint
+            float roll = smoothPath.m_Waypoints[nearestWaypointIndex].roll;
+            bool shouldPause = Mathf.Abs(roll) > rollThreshold;
+
+            if (shouldPause)
+            {
+                lastPausePosition = pathPosition;
+                Debug.Log(
+                    $"[CameraPathPanController] Pause point detected at waypoint {nearestWaypointIndex} with roll {roll:F2}"
+                );
+            }
+
+            return shouldPause;
+        }
+
+        private IEnumerator HandleFocusPoint()
+        {
+            // Smoothly stop
+            SetTargetSpeed(0);
+
+            // Wait until we've actually stopped
+            yield return new WaitUntil(() => Mathf.Abs(dollyCart.m_Speed) < 0.01f);
+
+            // Hold at focus point
+            yield return new WaitForSeconds(focusHoldTime);
+
+            // Smoothly resume
+            SetTargetSpeed(moveSpeed);
+        }
+
+        public void PauseTour()
+        {
+            if (tourRunning)
+            {
+                SetTargetSpeed(0);
+            }
+        }
+
+        public void ResumeTour()
+        {
+            if (tourRunning)
+            {
+                SetTargetSpeed(moveSpeed);
+            }
+        }
+
+        private void ResetTour()
+        {
+            lastPausePosition = -1f; // Reset the last pause position
+            // ...existing code...
+        }
+    }
+}

--- a/Truth and Shadows/Assets/Scripts/Camera/CameraPathPanController.cs.meta
+++ b/Truth and Shadows/Assets/Scripts/Camera/CameraPathPanController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bba8596736980d94d9675885e0707c9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Truth and Shadows/Assets/Scripts/Checkpoint.cs
+++ b/Truth and Shadows/Assets/Scripts/Checkpoint.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEngine;
 
 namespace TruthAndShadows.CheckpointSystem
@@ -47,8 +48,17 @@ namespace TruthAndShadows.CheckpointSystem
         [Tooltip(
             "If true, this checkpoint will always be used as the spawn point (for development/testing)"
         )]
+        [Header("Camera Path")]
+        [SerializeField]
+        private bool oneTimeCameraPath = true;
+
+        [SerializeField]
+        private int cameraPanPriority = 15; // Higher priority to ensure it overrides other cameras
+        private bool hasPlayedCameraPath = false;
+
         [SerializeField]
         private bool devOverrideSpawn = false;
+
         public bool DevOverrideSpawn => devOverrideSpawn;
 
         private Material runeMat;
@@ -57,6 +67,10 @@ namespace TruthAndShadows.CheckpointSystem
         private Transform player;
         private bool isLerpingToActivated = false;
         private readonly float lerpSpeed = 5f;
+
+        [SerializeField]
+        [Tooltip("Reference to the Runes child object that contains the mesh and collider")]
+        private Transform runesTransform;
 
         // Reference to the checkpoint's collider
         private Collider checkpointCollider;
@@ -69,19 +83,39 @@ namespace TruthAndShadows.CheckpointSystem
 
         private CheckpointManager _checkpointManager;
 
+        private ParticleSystem activationParticles;
+        private ParticleSystem secondaryActivationParticles;
+
         void Start()
         {
-            Debug.Log($"[Checkpoint] Start: {gameObject.name}");
-
             _checkpointManager = CheckpointManager.Instance;
 
-            // Cache the collider reference
-            checkpointCollider = GetComponent<Collider>();
-            if (checkpointCollider == null)
+            if (activationEffect != null)
             {
-                Debug.LogWarning(
-                    $"[Checkpoint] {gameObject.name} doesn't have a collider component!"
+                activationParticles = activationEffect.GetComponentInChildren<ParticleSystem>();
+            }
+
+            if (secondaryActivationEffect != null)
+            {
+                secondaryActivationParticles =
+                    secondaryActivationEffect.GetComponentInChildren<ParticleSystem>();
+            }
+
+            // Validate the Runes reference
+            if (runesTransform == null)
+            {
+                Debug.LogError(
+                    $"[Checkpoint] {gameObject.name} is missing Runes reference! Assign it in the inspector."
                 );
+                return;
+            }
+
+            // Cache and setup the collider reference
+            checkpointCollider = GetComponent<Collider>();
+            if (checkpointCollider != null)
+            {
+                // Ensure the collider is set as a trigger
+                checkpointCollider.isTrigger = true;
             }
 
             // Snap checkpoint to ground using a raycast
@@ -97,8 +131,7 @@ namespace TruthAndShadows.CheckpointSystem
                 )
             )
             {
-                transform.position = hit.point + Vector3.up * 0.0001f; // Slightly above ground
-                Debug.Log($"[Checkpoint] {gameObject.name} snapped to ground at {hit.point}");
+                transform.position = hit.point + Vector3.up * 0.001f;
             }
             else
             {
@@ -112,11 +145,10 @@ namespace TruthAndShadows.CheckpointSystem
                 );
                 _checkpointManager.AddCheckpoint(transform);
             }
-            runeMat = GetComponent<Renderer>().material;
+            runeMat = runesTransform.GetComponent<Renderer>().material;
             runeMat.EnableKeyword("_EMISSION");
             currentColor = farColor;
             UpdateGlow(currentColor);
-            Debug.Log($"[Checkpoint] Initial color set to {farColor}");
 
             // Find player by tag
             GameObject playerObj = GameObject.FindGameObjectWithTag("Player");
@@ -132,67 +164,87 @@ namespace TruthAndShadows.CheckpointSystem
                     $"[Checkpoint] {gameObject.name} is a spawn checkpoint, disabling effects"
                 );
                 DisableEffectsForSpawn();
-                return; // Skip further initialization for spawn checkpoints
             }
         }
 
         void Update()
         {
-            // Constant rotation
-            transform.Rotate(Vector3.forward, rotationSpeed * Time.deltaTime);
+            // Rotate the Runes child object
+            if (runesTransform != null)
+            {
+                runesTransform.Rotate(Vector3.forward, rotationSpeed * Time.deltaTime);
+            }
             if (isLerpingToActivated)
             {
                 currentColor = Color.Lerp(currentColor, activatedColor, Time.deltaTime * lerpSpeed);
                 UpdateGlow(currentColor);
-                Debug.Log(
-                    $"[Checkpoint] {gameObject.name} lerping to activatedColor: {activatedColor}"
-                );
                 if (Vector4.Distance(currentColor, activatedColor) < 0.01f)
                 {
                     currentColor = activatedColor;
                     UpdateGlow(currentColor);
                     isLerpingToActivated = false;
-                    Debug.Log($"[Checkpoint] {gameObject.name} finished lerping to activatedColor");
                 }
             }
         }
 
         private void OnTriggerEnter(Collider other)
         {
-            if (
-                !isActivated
-                && other.CompareTag("Player")
-                && _checkpointManager != null
-                && _checkpointManager.GetCurrentCheckpoint() != transform
-            )
+
+            if (isActivated)
             {
-                Debug.Log(
-                    $"[Checkpoint] Notifying CheckpointManager of activation for {gameObject.name} via trigger"
-                );
-                _checkpointManager.SetCheckpoint(transform);
-                TryActivateCameraPan();
+                return;
             }
+
+            if (!other.CompareTag("Player"))
+            {
+                return;
+            }
+
+            if (_checkpointManager == null)
+            {
+                return;
+            }
+
+            Transform currentCheckpoint = _checkpointManager.GetCurrentCheckpoint();
+            if (currentCheckpoint == transform)
+            {
+                return;
+            }
+
+            // Let the CheckpointManager handle the activation
+            _checkpointManager.SetCheckpoint(transform);
+            TryActivateCameraPathPan();
         }
 
         // Called when this checkpoint becomes the active checkpoint
         public void Activate()
         {
+
             if (isActivated && !effectsDisabledForSpawn)
             {
                 Debug.Log($"[Checkpoint] {gameObject.name} already activated, skipping");
                 return;
             }
+
+            Debug.Log($"[Checkpoint] Beginning activation sequence for {gameObject.name}");
             isActivated = true;
             isLerpingToActivated = true;
             effectsDisabledForSpawn = false;
-            Debug.Log(
-                $"[Checkpoint] {gameObject.name} activated! Starting lerp to {activatedColor}"
-            );
-            PlayEffect(activationEffect, "activation");
-            PlayEffect(secondaryActivationEffect, "secondary activation");
-            PlayActivationSound();
 
-            // Disable the collider once activated to prevent triggering again
+            // Play effects
+            if (activationParticles != null)
+            {
+                activationParticles.gameObject.SetActive(true);
+                PlayEffect(activationEffect, "activation");
+            }
+
+            if (secondaryActivationParticles != null)
+            {
+                secondaryActivationParticles.gameObject.SetActive(true);
+                PlayEffect(secondaryActivationEffect, "secondary activation");
+            }
+
+            PlayActivationSound();
             DisableCollider();
         }
 
@@ -202,7 +254,6 @@ namespace TruthAndShadows.CheckpointSystem
             if (checkpointCollider != null)
             {
                 checkpointCollider.enabled = false;
-                Debug.Log($"[Checkpoint] Disabled collider for {gameObject.name}");
             }
         }
 
@@ -212,7 +263,6 @@ namespace TruthAndShadows.CheckpointSystem
             if (checkpointCollider != null && !isActivated)
             {
                 checkpointCollider.enabled = true;
-                Debug.Log($"[Checkpoint] Enabled collider for {gameObject.name}");
             }
         }
 
@@ -223,26 +273,21 @@ namespace TruthAndShadows.CheckpointSystem
 
         private void PlayEffect(GameObject effectObj, string effectName)
         {
-            if (effectObj != null)
+            ParticleSystem ps =
+                effectName == "activation" ? activationParticles : secondaryActivationParticles;
+
+            if (ps != null)
             {
-                Debug.Log($"[Checkpoint] Playing {effectName} effect for {gameObject.name}");
-                var ps = effectObj.GetComponent<ParticleSystem>();
-                if (ps != null)
+                ps.gameObject.SetActive(true);
+                var main = ps.main;
+                main.loop = false;
+
+                // Make sure the particle system is awake and ready
+                if (!ps.isPlaying)
                 {
-                    ps.Play();
+                    ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                    ps.Play(true);
                 }
-                else
-                {
-                    Debug.LogWarning(
-                        $"[Checkpoint] {effectName}Effect on {gameObject.name} does not have a ParticleSystem component."
-                    );
-                }
-            }
-            else
-            {
-                Debug.LogWarning(
-                    $"[Checkpoint] No {effectName}Effect assigned for {gameObject.name}"
-                );
             }
         }
 
@@ -250,7 +295,6 @@ namespace TruthAndShadows.CheckpointSystem
         {
             if (activationSound != null)
             {
-                Debug.Log($"[Checkpoint] Playing activation sound for {gameObject.name}");
                 if (audioSource != null)
                 {
                     audioSource.PlayOneShot(activationSound);
@@ -259,10 +303,6 @@ namespace TruthAndShadows.CheckpointSystem
                 {
                     AudioSource.PlayClipAtPoint(activationSound, transform.position);
                 }
-            }
-            else
-            {
-                Debug.LogWarning($"[Checkpoint] No activationSound assigned for {gameObject.name}");
             }
         }
 
@@ -278,39 +318,35 @@ namespace TruthAndShadows.CheckpointSystem
                 UpdateGlow(currentColor);
             }
 
-            if (activationEffect != null)
-            {
-                var ps = activationEffect.GetComponent<ParticleSystem>();
-                if (ps != null)
-                    ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
-            }
-            if (secondaryActivationEffect != null)
-            {
-                var ps2 = secondaryActivationEffect.GetComponent<ParticleSystem>();
-                if (ps2 != null)
-                    ps2.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
-            }
+            // Stop particle systems using cached references
+            if (activationParticles != null)
+                activationParticles.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
 
-            // Disable the renderer for the spawn checkpoint
-            var rend = GetComponent<Renderer>();
-            if (rend != null)
-                rend.enabled = false;
+            if (secondaryActivationParticles != null)
+                secondaryActivationParticles.Stop(
+                    true,
+                    ParticleSystemStopBehavior.StopEmittingAndClear
+                );
+
+            // Disable the renderer for the spawn checkpoint's Runes
+            if (runesTransform != null)
+            {
+                var rend = runesTransform.GetComponent<Renderer>();
+                if (rend != null)
+                    rend.enabled = false;
+            }
 
             // Disable the collider for the spawn checkpoint
             DisableCollider();
-
-            Debug.Log(
-                $"[Checkpoint] {gameObject.name} effects, renderer, and collider disabled for spawn"
-            );
         }
 
         void UpdateGlow(Color glowColor)
         {
-            runeMat.SetColor("_EmissionColor", glowColor * glowIntensity);
-            DynamicGI.SetEmissive(GetComponent<Renderer>(), glowColor * glowIntensity);
-            Debug.Log(
-                $"[Checkpoint] {gameObject.name} emission color updated to {glowColor * glowIntensity}"
-            );
+            if (runeMat != null && runesTransform != null)
+            {
+                runeMat.SetColor("_EmissionColor", glowColor * glowIntensity);
+                DynamicGI.SetEmissive(GetComponent<Renderer>(), glowColor * glowIntensity);
+            }
         }
 
         public static Checkpoint GetDevOverrideCheckpoint()
@@ -326,35 +362,15 @@ namespace TruthAndShadows.CheckpointSystem
         }
 
         /// <summary>
-        /// Checks if a CameraPanController component exists on this game object and activates it if found.
-        /// Returns true if the controller was found and activated, false otherwise.
+        /// Tries to play the camera path tour if a CameraPathPanController is attached
         /// </summary>
-        /// <param name="customDuration">Optional custom duration for the camera pan in seconds. If -1, uses the default duration.</param>
-        /// <returns>True if the camera pan was activated, false if no controller was found.</returns>
-        public bool TryActivateCameraPan(float customDuration = -1)
+        private void TryActivateCameraPathPan()
         {
-            // Try to get the CameraPanController component
-            var cameraPanController = GetComponent<Interaction.CameraPanController>();
-
-            // Check if we found a controller
-            if (cameraPanController != null)
+            var cameraPathController = GetComponent<Interaction.CameraPathPanController>();
+            if (cameraPathController != null)
             {
-                // If a custom duration was provided, use the CameraPan method
-                if (customDuration > 0)
-                {
-                    cameraPanController.CameraPan(customDuration);
-                }
-                // Otherwise, just activate with default duration
-                else
-                {
-                    cameraPanController.Activate();
-                }
-
-                return true; // Successfully activated
+                cameraPathController.PlayTourIfAble();
             }
-
-            // No controller found
-            return false;
         }
     }
 }

--- a/Truth and Shadows/Assets/Scripts/CheckpointManager.cs
+++ b/Truth and Shadows/Assets/Scripts/CheckpointManager.cs
@@ -303,20 +303,20 @@ namespace TruthAndShadows.CheckpointSystem
         public void ResetAllCheckpoints()
         {
             Debug.Log("[CheckpointManager] Resetting all checkpoints");
-            
+
             foreach (var checkpointTransform in checkpoints)
             {
                 if (checkpointTransform == null)
                 {
                     continue;
                 }
-                
+
                 Checkpoint cp = checkpointTransform.GetComponent<Checkpoint>();
                 if (cp == null)
                 {
                     continue;
                 }
-                
+
                 // Skip the current active checkpoint
                 if (checkpointTransform == currentCheckpoint)
                 {


### PR DESCRIPTION
Introduces CameraPathPanController for Cinemachine-based camera tours on checkpoint activation. Updates Checkpoint prefab and script to support one-time camera path playback, references to Runes mesh, and improved effect handling. Refactors CheckpointManager and Checkpoint for better modularity and camera integration.